### PR TITLE
fix: update composer to solve ci jq error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,8 @@
 {
   "name": "islandora_lite/termwithuri_condition",
   "type": "drupal-module",
-  "description": "This module provide Node/Media has term with URI conditions"
+  "description": "This module provide Node/Media has term with URI conditions",
+  "require": {
+    "drupal/core": "^10 || ^11"
+  }
 }


### PR DESCRIPTION
# Description
This PR updates the composer file by adding required section to solve the error `jq: error (at web/modules/contrib/termwithuri_condition/composer.json:5): null (null) has no keys`.